### PR TITLE
Add the install-your-fonts proposal as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ the web. You're welcome to [contribute](CONTRIBUTING.md)!
 - [Proposal](#proposal)
   - [Allowed system fonts](#allowed-system-fonts)
   - [Aggressively-cached web fonts](#aggressively-cached-web-fonts)
+  - [Explicitly provide uncommon but desired fonts to the browser](#explicitly-provide-uncommon-but-desired-fonts-to-the-browser)
 - [Key scenarios](#key-scenarios)
 - [Detailed design discussion](#detailed-design-discussion)
   - [When to cache the webfonts](#when-to-cache-the-webfonts)
@@ -58,17 +59,16 @@ Make font-based queries useless for distinguishing any two users running:
 * on the same version of the same operating system
 * in the same [locale](#locale).
 
-This identifiability should be minimized as much as possible, without harming
-the following use cases:
+This identifiability should be minimized as much as possible, with as little
+harm as possible to the following use cases:
 
-* websites that expect an uncommon font to already be available in the visitor's
-  browser should continue to work as designed (e.g. don't break sites targeting
-  languages where users know they must install a uncommon-but-important-font).
-* web developers should be able to use uncommon fonts on their local machines,
-  for efficient, offline site development.
-* web users should be able to improve the performance of websites by
-  "pre-loading" fonts they expect they will need a lot (e.g. data sensitive
-  users can install web-fonts to prevent network load).
+* Web users who have been installing web fonts over cheap connections to avoid
+  spending money or time downloading them on expensive or slow connections,
+  shouldn't now have to use the expensive or slow connections.
+* Websites that depend on a font that's commonly installed among their visitors,
+  but uncommon on the web, should have a way to continue working.
+* Web developers should be able to use uncommon fonts on their local machines
+  even when developing offline.
 
 ## Non-goals
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Make font-based queries useless for distinguishing any two users running:
 This identifiability should be minimized as much as possible, with as little
 harm as possible to the following use cases:
 
-* Web users who have been installing web fonts over cheap connections to avoid
-  spending money or time downloading them on expensive or slow connections,
+* Web users with cheap connections who use badly-supported minority languages,
+  and thus have been installing fonts for their language locally
+  to avoid spending money or time downloading them on expensive or slow connections,
   shouldn't now have to use the expensive or slow connections.
 * Websites that depend on a font that's commonly installed among their visitors,
   but uncommon on the web, should have a way to continue working.

--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ non-default fonts.
 
 ## Proposal
 
-Each browser will be able to map from a locale (as in [Goals](#goals), just the
-negotiated language+country pair, not the whole `Accept-Language` list) to:
+Each browser has a map from a [locale](#locale) to a set of fonts that it
+ensures are available locally, and which are the only fonts usable with
+`src:local()`(https://www.w3.org/TR/css-fonts-3/#font-face-name-value). There
+are several options for which fonts are in this set.
 
 ### Allowed system fonts
 
@@ -101,6 +103,19 @@ allow use of pre-installed fonts in places like the `@font-face` `src:`
 [`local()`](https://www.w3.org/TR/css-fonts-3/#font-face-name-value) function
 and the [`font-family`
 property](https://www.w3.org/TR/css-fonts-3/#font-family-prop).
+
+### Aggressively-cached web fonts
+
+The set of most-commonly-used web fonts for each locale will be derived from
+metrics gathered from browser telemetry. We should share a single list across
+all browsers, and publicize this list so developers can rely on it. TODO: Figure
+out how much usage makes a font one of the most-commonly-used fonts. Is that a
+number or disk-size of fonts, a percentage of page loads, or what?
+
+The first time a user visits a page that uses one of these fonts, it's
+downloaded and cached until it's no longer in the set of commonly-used fonts,
+which could be forever. See [When to cache the
+webfonts](#when-to-cache-the-webfonts).
 
 ### Explicitly provide uncommon but desired fonts to the browser
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Make font-based queries useless for distinguishing any two users running:
 * on the same version of the same operating system
 * in the same [locale](#locale).
 
+This identifiability should be minimized as much as possible, without harming
+the following use cases:
+
+* websites that expect an uncommon font to already be available in the visitor's
+  browser should continue to work as designed (e.g. don't break sites targeting
+  languages where users know they must install a uncommon-but-important-font).
+* web developers should be able to use uncommon fonts on their local machines,
+  for efficient, offline site development.
+* web users should be able to improve the performance of websites by
+  "pre-loading" fonts they expect they will need a lot (e.g. data sensitive
+  users can install web-fonts to prevent network load).
+
 ## Non-goals
 
 Attempts to reduce identifiability based on locale, browser, or OS choice are
@@ -90,18 +102,29 @@ allow use of pre-installed fonts in places like the `@font-face` `src:`
 and the [`font-family`
 property](https://www.w3.org/TR/css-fonts-3/#font-family-prop).
 
-### Aggressively-cached web fonts
+### Explicitly provide uncommon but desired fonts to the browser
 
-The set of most-commonly-used web fonts for each locale will be derived from
-metrics gathered from browser telemetry. We should share a single list across
-all browsers, and publicize this list so developers can rely on it. TODO: Figure
-out how much usage makes a font one of the most-commonly-used fonts. Is that a
-number or disk-size of fonts, a percentage of page loads, or what?
+The main source of identification in font-based fingerprinting is the long
+tail of fonts users have installed (sometimes w/o realizing it) that they
+**do not expect or intend websites to access**; fonts-intentionally installed
+for web-use are relatively un-identifying (both because many of these use
+cases will put users in significant anonymity sets, largely because users
+installing fonts needed for less-common-language sites will already overlap
+with the "locale" anonymity set).
 
-The first time a user visits a page that uses one of these fonts, it's
-downloaded and cached until it's no longer in the set of commonly-used fonts,
-which could be forever. See [When to cache the
-webfonts](#when-to-cache-the-webfonts).
+Browsers can maintain existing important use cases, w/o (in most cases)
+increasing the identifiability of the browser by removing the ambiguity
+between "fonts that were installed on the machine for non-web purposes" and
+"fonts that were installed on the machine for web purposes".  This should
+be accomplished through browser settings / "chrome" allowing users to explicitly
+describe which fonts the browser should be able to access
+**beyond the OS provided fonts**.
+
+This might take the form of selecting fonts the operating system knows about
+(e.g. Windows knows about these 30 fonts Windows didn't ship with, select
+which fonts you'd like websites to know about), or an alternate "install
+a font into the browser" flow.
+
 
 ## Key scenarios
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ Make font-based queries useless for distinguishing any two users running:
 This identifiability should be minimized as much as possible, with as little
 harm as possible to the following use cases:
 
-* Web users with cheap connections who use badly-supported minority languages,
-  and thus have been installing fonts for their language locally
-  to avoid spending money or time downloading them on expensive or slow connections,
+* Web users who have been installing web fonts over cheap connections to avoid
+  spending money or time downloading them on expensive or slow connections,
   shouldn't now have to use the expensive or slow connections.
 * Websites that depend on a font that's commonly installed among their visitors,
   but uncommon on the web, should have a way to continue working.


### PR DESCRIPTION
I haven't fully integrated the proposal into the text (e.g. if we go this route, text further down doesn't make sense), but wanted to write the proposal down.

TL;DR;

- The problem is the long tail fonts on the system users don't want browsers to know about
- Font people want sites to know about are much less likely to be identifying.  For example, they'll be in overlapping anonymity sets with locale
- Building lists is difficult and makes the web crusty and ossified (though lists are better than nothing)
- Building mega caches is expensive and doesn't solve all use cases
- Users who intentionally want certain fonts in the browser are likely to already be taking extra steps (seeking and installing the language specific font(s), installing a font for local dev work, etc)

We can solve all the above by removing ambiguity about which fonts users want browsers to know about.