### PR TITLE
Allow more options for when to download the common web fonts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,23 @@ all browsers, and publicize this list so developers can rely on it. TODO: Figure
 out how much usage makes a font one of the most-commonly-used fonts. Is that a
 number or disk-size of fonts, a percentage of page loads, or what?
 
-The first time a user visits a page that uses one of these fonts, it's
-downloaded and cached until it's no longer in the set of commonly-used fonts,
-which could be forever. See [When to cache the
-webfonts](#when-to-cache-the-webfonts).
+This set of fonts is aggressively downloaded and cached until it's no longer in
+the set of commonly-used fonts, which could be forever. The details of when to
+download the fonts should align with the [Web Shared
+Libraries](https://docs.google.com/document/d/1lQykm9HgzkPlaKXwpQ9vNc3m2Eq2hF4TY-Vup5wg4qg/edit)
+proposal. There is a tradeoff between:
+
+* precaching, which may waste transferred bytes for fonts that a particular user
+  never uses
+* caching on first use, which in a few cases might expose that a user visited
+  one of a sensitive set of sites to an attacker,
+* not allowing this set of fonts at all, which either leads to slow and
+  expensive page loads or a need to change site or user behavior, and
+* allowing font fingerprinting.
+
+Different browsers might make different choices within this tradeoff.
+
+See [When to cache the webfonts](#when-to-cache-the-webfonts).
 
 ## Key scenarios
 
@@ -111,14 +124,18 @@ TODO: look through discussion threads to check that this solves the objections.
 
 ### When to cache the webfonts
 
-It would be safest to pre-cache all of these fonts when a new major version of a
+It's safest to pre-cache all of these fonts when a new major version of a
 browser is installed, but this might waste valuable bandwidth and disk space for
 a font that a particular user never happens to need.
 
-I believe it's also safe to cache each font at the point where it's first used,
-as long as the cache never evicts fonts. This allows exactly one site to
-determine that a user has not visited any site that either uses the font or has
-tried to learn this fact about the user.
+Caching each font at the point where it's first used, if the cache never evicts
+fonts, allows exactly one site to determine that a user has not visited any site
+that either uses the font or has tried to learn this fact about the user. If
+exactly one attacker notices a sensitive set of sites using a font, and that set
+is large enough to make the font "common", and the attacker has logged-in users,
+they might be able to probe each user exactly once in order to distinguish users
+who've visited the sensitive set without polluting their sample with users who
+have previously been attacked.
 
 If the user removes a locale from their `Accept-Language` list, it's plausible to
 evict fonts that aren't common for their new set of locales. If the user then


### PR DESCRIPTION
And describe the possible history leak in more detail.

@bholley @annevk, can you let me know if this is an accurate description of the problem in #7, and whether the extra flexibility here makes you like the proposal better? Do you think it's important that all browsers align on when fonts are cached? I *think* that particular difference can't introduce pressure to align with the most popular browser, although I could be wrong.